### PR TITLE
File heading comment

### DIFF
--- a/include/README.md
+++ b/include/README.md
@@ -11,5 +11,5 @@ There are also a few files in this directory:
 
  + `lit.h` the must-include header to work with lit
  + `lit_common.h` some useful includes like bools and int types
- + `lit_debug.h` provides some pretty ast and bytecode outputs
+ + `lit_debug.h` provides some pretty abstract syntax tree (AST) and bytecode outputs
  + `lit_mem_manager.h` provides a simple interface for controlling memory allocation (and leaks)

--- a/src/cli/lit_core.c
+++ b/src/cli/lit_core.c
@@ -1,5 +1,12 @@
-#include <string.h>
+/*
+ * lit_core.c --- ADD short description
+ * 
+ *
+ * Copyright 2018 by Egor Dorichev. 
+ * This file may be redistributed under the GNU Public License v2.
+ */
 
+#include <string.h>
 #include <cli/lit_core.h>
 
 void lit_init_core(LitVm* vm) {


### PR DESCRIPTION
1. **lit_core.c** Please look on the heading comment suggested to use in the files. The format was borrowed from the kernel.org files.

2. **README.md** AST was explained, as we discussed.